### PR TITLE
docs: fix modern theme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,23 @@
 
 1. Download your preferred style:
   - Default (looks like the default "Alfred" style)
-    - [Mocha](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-mocha.alfredappearance)
-    - [Macchiato](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-macchiato.alfredappearance)
-    - [Frappe](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-frappe.alfredappearance)
-    - [Latte](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-latte.alfredappearance)
-
-  - Modern (looks like the "Alfred Modern" style, screenshot above)
     - [Mocha](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-default-mocha.alfredappearance)
     - [Macchiato](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-default-macchiato.alfredappearance)
     - [Frappe](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-default-frappe.alfredappearance)
     - [Latte](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-default-latte.alfredappearance)
+
+  - Modern (looks like the "Alfred Modern" style, screenshot above)
+    - [Mocha](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-mocha.alfredappearance)
+    - [Macchiato](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-macchiato.alfredappearance)
+    - [Frappe](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-frappe.alfredappearance)
+    - [Latte](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-modern-latte.alfredappearance)
 
   - macOS (looks like the "Alfred macOS" style)
     - [Mocha](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-macOS-mocha.alfredappearance)
     - [Macchiato](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-macOS-macchiato.alfredappearance)
     - [Frappe](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-macOS-frappe.alfredappearance)
     - [Latte](https://raw.githubusercontent.com/catppuccin/alfred/main/dist/Catppuccin-macOS-latte.alfredappearance)
+
 2. Open the file, and Alfred will import it
 3. Select the theme under "Appearance" in Alfred Preferences
 


### PR DESCRIPTION
The "modern" theme links were pointing to the default theme instead.